### PR TITLE
patched bug in the Background Parallax Script

### DIFF
--- a/Senior Project Infinity Run/Assets/New Assets/Background/Archived.meta
+++ b/Senior Project Infinity Run/Assets/New Assets/Background/Archived.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 911e2f49ed4052245834b0abc2430792
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Senior Project Infinity Run/Assets/New Assets/Background/Archived/Archived_Background_Parallax.cs
+++ b/Senior Project Infinity Run/Assets/New Assets/Background/Archived/Archived_Background_Parallax.cs
@@ -1,0 +1,104 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Archived_Background_Parallax : MonoBehaviour
+{
+    //needed for new funcs
+    Vector3 PreviousCameraPosition;
+    Vector3 FarthestLayerPosition;
+
+    //new vals for different
+    private Transform mainCameraTransform;
+    private Vector3 lastCameraPosition;
+    public float ParallaxFactor = 0;
+    // Start is called before the first frame update
+    void Start()
+    {
+        PreviousCameraPosition = Camera.main.transform.position;
+        FarthestLayerPosition = this.gameObject.transform.parent.GetChild(this.gameObject.transform.parent.childCount - 1).transform.position;
+
+        //diff needs
+        mainCameraTransform = Camera.main.transform;
+        lastCameraPosition = mainCameraTransform.position;
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+
+        BruteForceParallax();
+
+    }
+
+    void BruteForceParallax()
+    {
+        Vector3 cameraMovement = mainCameraTransform.position - lastCameraPosition;
+        Vector3 layerPosition = transform.position;
+
+        // Calculate the parallax factor based on the GameObject's z position.
+        //float parallaxFactor = transform.position.z + 1; // Adding 1 to avoid division by zero.
+
+        layerPosition.x += cameraMovement.x * ParallaxFactor;
+
+
+        transform.position = layerPosition;
+        lastCameraPosition = mainCameraTransform.position;
+    }
+
+    //methods below flawed and are not to be used in production
+    void NewestParallax()
+    {
+        //speed needs to increase as it approaches the camera. needs to make the"midpoint" or 0 at the pc ground layer. this should not move.
+        //objects farther than the 0 layer need to move slower than the camera the farther they get
+        //objects closer than the 0 layer need to move faster than the camera closer they get
+        float layerParallaxSpeed = this.gameObject.transform.position.z;
+
+        Camera cam = Camera.main;
+        float cameraDisplacement = cam.transform.position.x - PreviousCameraPosition.x;
+
+
+        this.gameObject.transform.position = this.gameObject.transform.parent.transform.position + new Vector3(1f / cameraDisplacement * layerParallaxSpeed, transform.position.y, transform.position.z);
+
+        Debug.Log(this.gameObject.transform.position.x);
+
+        PreviousCameraPosition = Camera.main.transform.position;
+
+    }
+    void NewParallax()
+    {
+        /*
+         move along the x axis based on the maincamera transform. this is multiplied by the layers z position
+        slightly follows the camera as it moves up and down
+         */
+        Camera cam = Camera.main;
+        float cameraXDisplacement = cam.transform.position.x - PreviousCameraPosition.x;
+        PreviousCameraPosition = Camera.main.transform.position;
+
+
+
+        float layerCurrentZ = this.transform.position.z;
+        float layerCurrentY = cam.transform.position.y / 100;
+        float layerMultiplier = (layerCurrentZ) / this.gameObject.transform.parent.GetChild(this.gameObject.transform.parent.transform.childCount - 1).transform.position.z;
+        float parallaxSpeedModifier = this.gameObject.GetComponentInParent<Background_Extender>().ParallaxFactor;//getting from parent script
+        float layerNewX = cameraXDisplacement * layerMultiplier * parallaxSpeedModifier;//not sure why the - is neccessary atm
+        Vector3 newLayerPosition = new Vector3(layerNewX, layerCurrentY, layerCurrentZ);
+        this.gameObject.transform.position = this.gameObject.transform.parent.transform.position + newLayerPosition;
+    }
+    void OldParallax()
+    {
+        /*
+         move along the x axis based on the maincamera transform. this is multiplied by the layers z position
+         */
+        Camera cam = Camera.main;
+
+        float layerCurrentZ = this.transform.position.z;
+        float layerCurrentY = this.transform.position.y;
+        float layerMultiplier = 1 / layerCurrentZ;
+        float parallaxSpeedModifier = this.gameObject.GetComponentInParent<Background_Extender>().ParallaxFactor;//getting from parent script
+        float layerNewX = -1 * cam.transform.position.x * layerMultiplier * parallaxSpeedModifier;//not sure why the - is neccessary atm
+        Vector3 newLayerPosition = new Vector3(layerNewX, layerCurrentY, layerCurrentZ);
+
+        this.gameObject.transform.position = this.gameObject.transform.parent.transform.position + newLayerPosition;
+    }
+}

--- a/Senior Project Infinity Run/Assets/New Assets/Background/Archived/Archived_Background_Parallax.cs.meta
+++ b/Senior Project Infinity Run/Assets/New Assets/Background/Archived/Archived_Background_Parallax.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a2aee910af481b34aa26e205a0738a7c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Senior Project Infinity Run/Assets/New Assets/Background/Background Chunk.prefab
+++ b/Senior Project Infinity Run/Assets/New Assets/Background/Background Chunk.prefab
@@ -69,7 +69,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 589457421357852349}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 9}
+  m_LocalPosition: {x: 0, y: 0, z: 70}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -140,6 +140,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6d6807b326cfac14192f1170401f69c1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  ParallaxFactor: 0.8
 --- !u!1 &1408441512025708485
 GameObject:
   m_ObjectHideFlags: 0
@@ -166,7 +167,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1408441512025708485}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 12}
+  m_LocalPosition: {x: 0, y: 0, z: 100}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -237,6 +238,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6d6807b326cfac14192f1170401f69c1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  ParallaxFactor: 1
 --- !u!1 &1831931422947021906
 GameObject:
   m_ObjectHideFlags: 0
@@ -263,7 +265,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1831931422947021906}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 3}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -334,6 +336,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6d6807b326cfac14192f1170401f69c1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  ParallaxFactor: 0
 --- !u!1 &2742172537523581162
 GameObject:
   m_ObjectHideFlags: 0
@@ -360,7 +363,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2742172537523581162}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 8}
+  m_LocalPosition: {x: 0, y: 0, z: 60}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -431,6 +434,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6d6807b326cfac14192f1170401f69c1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  ParallaxFactor: 0.7
 --- !u!1 &2956639530925058661
 GameObject:
   m_ObjectHideFlags: 0
@@ -457,7 +461,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2956639530925058661}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 3}
+  m_LocalPosition: {x: 0, y: 0, z: 5}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -528,6 +532,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6d6807b326cfac14192f1170401f69c1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  ParallaxFactor: 0.2
 --- !u!1 &3879173181630737087
 GameObject:
   m_ObjectHideFlags: 0
@@ -554,7 +559,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3879173181630737087}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 10}
+  m_LocalPosition: {x: 0, y: 0, z: 80}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -625,6 +630,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6d6807b326cfac14192f1170401f69c1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  ParallaxFactor: 0.9
 --- !u!1 &4280967985080635302
 GameObject:
   m_ObjectHideFlags: 0
@@ -651,7 +657,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4280967985080635302}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 6}
+  m_LocalPosition: {x: 0, y: 0, z: 12}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -722,6 +728,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6d6807b326cfac14192f1170401f69c1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  ParallaxFactor: 0.5
 --- !u!1 &5468819879170173899
 GameObject:
   m_ObjectHideFlags: 0
@@ -748,7 +755,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5468819879170173899}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 11}
+  m_LocalPosition: {x: 0, y: 0, z: 90}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -819,6 +826,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6d6807b326cfac14192f1170401f69c1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  ParallaxFactor: 0.99
 --- !u!1 &6564078217766124230
 GameObject:
   m_ObjectHideFlags: 0
@@ -845,7 +853,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6564078217766124230}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 5}
+  m_LocalPosition: {x: 0, y: 0, z: 9}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -916,6 +924,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6d6807b326cfac14192f1170401f69c1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  ParallaxFactor: 0.4
 --- !u!1 &7151606666168504702
 GameObject:
   m_ObjectHideFlags: 0
@@ -942,7 +951,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7151606666168504702}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 2}
+  m_LocalPosition: {x: 0, y: 0, z: 4}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1013,6 +1022,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6d6807b326cfac14192f1170401f69c1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  ParallaxFactor: 0.01
 --- !u!1 &7191770058507078888
 GameObject:
   m_ObjectHideFlags: 0
@@ -1024,7 +1034,6 @@ GameObject:
   - component: {fileID: 6006873735592713546}
   - component: {fileID: 2709310217426371230}
   - component: {fileID: 951834497437576343}
-  - component: {fileID: 5957764066830204279}
   m_Layer: 0
   m_Name: Layer (6)
   m_TagString: Untagged
@@ -1040,7 +1049,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7191770058507078888}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 7}
+  m_LocalPosition: {x: 0, y: 0, z: 40}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1111,18 +1120,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6d6807b326cfac14192f1170401f69c1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &5957764066830204279
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7191770058507078888}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6d6807b326cfac14192f1170401f69c1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  ParallaxFactor: 0.6
 --- !u!1 &8963986218973774413
 GameObject:
   m_ObjectHideFlags: 0
@@ -1149,7 +1147,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8963986218973774413}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 4}
+  m_LocalPosition: {x: 0, y: 0, z: 6}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1220,3 +1218,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6d6807b326cfac14192f1170401f69c1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  ParallaxFactor: 0.3

--- a/Senior Project Infinity Run/Assets/New Assets/Background/Background Extender.prefab
+++ b/Senior Project Infinity Run/Assets/New Assets/Background/Background Extender.prefab
@@ -46,4 +46,4 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   referenceBackgroundChunk: {fileID: 196283789300057250, guid: c140b08e9ca4fbb4ea64812224918ff0, type: 3}
   ChunksToPlace: 100
-  ParralaxFactor: 2
+  ParallaxFactor: 1

--- a/Senior Project Infinity Run/Assets/New Assets/Background/Background_Parallax.cs
+++ b/Senior Project Infinity Run/Assets/New Assets/Background/Background_Parallax.cs
@@ -3,28 +3,38 @@ using System.Collections.Generic;
 using UnityEngine;
 
 public class Background_Parallax : MonoBehaviour
-{
+{//this implementation uses hardcoded parallax values to shift each layer. Ideally, we can upgrade the script to allow for dynamic assignment of the parallax value based on either distance from the camera on the z axis, the layers z position, or based on the ground layer z position
+    //new vals for different
+    private Transform mainCameraTransform;
+    private Vector3 lastCameraPosition;
+    public float ParallaxFactor = 0;
     // Start is called before the first frame update
     void Start()
     {
-        
+        mainCameraTransform = Camera.main.transform;
+        lastCameraPosition = mainCameraTransform.position;
     }
 
     // Update is called once per frame
     void Update()
     {
-        /*
-         move along the x axis based on the maincamera transform. this is multiplied by the layers z position
-         */
-        Camera cam = Camera.main;
 
-        float layerCurrentZ = this.transform.position.z;
-        float layerCurrentY = this.transform.position.y;
-        float layerMultiplier = 1/layerCurrentZ;
-        float parallaxSpeedModifier = this.gameObject.GetComponentInParent<Background_Extender>().ParallaxFactor;//getting from parent script
-        float layerNewX = -cam.transform.position.x * layerMultiplier * parallaxSpeedModifier;//not sure why the - is neccessary atm
-        Vector3 newLayerPosition = new Vector3(layerNewX, layerCurrentY, layerCurrentZ);
+        BruteForceParallax();
+       
+    }
 
-        this.gameObject.transform.position = this.gameObject.transform.parent.transform.position + newLayerPosition;
+    void BruteForceParallax()
+    {
+        Vector3 cameraMovement = mainCameraTransform.position - lastCameraPosition;
+        Vector3 layerPosition = transform.position;
+
+        // Calculate the parallax factor based on the GameObject's z position.
+        //float parallaxFactor = transform.position.z + 1; // Adding 1 to avoid division by zero.
+
+        layerPosition.x += cameraMovement.x * ParallaxFactor;
+        
+
+        transform.position = layerPosition;
+        lastCameraPosition = mainCameraTransform.position;
     }
 }

--- a/Senior Project Infinity Run/Assets/New Assets/Background/Testing Background.unity
+++ b/Senior Project Infinity Run/Assets/New Assets/Background/Testing Background.unity
@@ -123,6 +123,67 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1001 &9097480
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_RootOrder
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 20.55
+      objectReference: {fileID: 0}
+    - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -7.57
+      objectReference: {fileID: 0}
+    - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7744293898016202459, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_Name
+      value: Platform (2)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
 --- !u!1001 &259897365
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -132,11 +193,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
       propertyPath: m_RootOrder
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
       propertyPath: m_LocalScale.x
-      value: 1000
+      value: 435
       objectReference: {fileID: 0}
     - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
       propertyPath: m_LocalPosition.x
@@ -181,6 +242,67 @@ PrefabInstance:
     - target: {fileID: 7744293898016202459, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
       propertyPath: m_Name
       value: Platform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+--- !u!1001 &440808437
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_RootOrder
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 43.89
+      objectReference: {fileID: 0}
+    - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 5.27
+      objectReference: {fileID: 0}
+    - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7744293898016202459, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_Name
+      value: Platform (5)
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
@@ -241,6 +363,128 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 5fda1b4122acae541b85004687629a2c, type: 3}
+--- !u!1001 &737706871
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 14.67085
+      objectReference: {fileID: 0}
+    - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -10.707209
+      objectReference: {fileID: 0}
+    - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7744293898016202459, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_Name
+      value: Platform (1)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+--- !u!1001 &894641102
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_RootOrder
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 27.02
+      objectReference: {fileID: 0}
+    - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -4.24
+      objectReference: {fileID: 0}
+    - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7744293898016202459, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_Name
+      value: Platform (3)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
 --- !u!1001 &905259087
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -254,7 +498,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6378508889249673594, guid: 9e2fe78e132140c439377059ec12215c, type: 3}
       propertyPath: m_RootOrder
-      value: 3
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 6378508889249673594, guid: 9e2fe78e132140c439377059ec12215c, type: 3}
       propertyPath: m_LocalPosition.x
@@ -296,8 +540,73 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 8776888570349600856, guid: 9e2fe78e132140c439377059ec12215c, type: 3}
+      propertyPath: ParallaxFactor
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 9e2fe78e132140c439377059ec12215c, type: 3}
+--- !u!1001 &1255164985
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_RootOrder
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 33.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.07
+      objectReference: {fileID: 0}
+    - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4302278203754363465, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7744293898016202459, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
+      propertyPath: m_Name
+      value: Platform (4)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8b877f28b7f823647ba99730dd0e6d1e, type: 3}
 --- !u!1001 &1372290128
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -311,7 +620,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 400002, guid: e7e7a8e5fa6422740801a3c8bb6fd813, type: 3}
       propertyPath: m_RootOrder
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 400002, guid: e7e7a8e5fa6422740801a3c8bb6fd813, type: 3}
       propertyPath: m_LocalPosition.x


### PR DESCRIPTION
1.)changed the method of shifting the background layers position to facilitate parallax into a brute force solution. 1.1) the solution takes a preset parallax factor for each layer and uses that to shift it appropriately according to how far the camera shifted since the last frame. 1.2) Changed the Background chunk prefab to facilitate this change by manually setting the public parallax factor variable for each layer by hand.

2) archived the old background parallax script, allowing the clean up of unnecessary code within the new version of the script.

Note: It may be worth considering a method for modifying the parallax speed for each layer based on it's z position for easier development of new backgrounds and adjustment of layer position, however, this hard coded solution seems to be sufficient for the moment