### PR TITLE
Fixed Hitbox Flipping

### DIFF
--- a/Senior Project Infinity Run/Assets/New Assets/Enemys/Monsters/Monsters/Skeleton/Skeleton_Movement.cs
+++ b/Senior Project Infinity Run/Assets/New Assets/Enemys/Monsters/Monsters/Skeleton/Skeleton_Movement.cs
@@ -59,7 +59,8 @@ public class Skeleton_Movement : MonoBehaviour
         Stats = gameObject.GetComponent<Skeleton_Stats>();
 
         //face left
-        GetComponent<SpriteRenderer>().flipX = true;
+        transform.rotation = Quaternion.Euler(0, 180f, 0);
+        //GetComponent<SpriteRenderer>().flipX = true;
     }
 
     // Update is called once per frame
@@ -117,7 +118,8 @@ public class Skeleton_Movement : MonoBehaviour
         }
         if (controls.shouldMoveLeftNextFixedUpdate)
         {
-            GetComponent<SpriteRenderer>().flipX = true;
+            transform.rotation = Quaternion.Euler(0, 180f, 0);
+            //GetComponent<SpriteRenderer>().flipX = true;
             MoveMe(new Vector3(-1 * movementSpeedMultiplier, 0, 0));
         }
         if (controls.shouldMoveDownNextFixedUpdate)
@@ -126,7 +128,8 @@ public class Skeleton_Movement : MonoBehaviour
         }
         if (controls.shouldMoveRightNextFixedUpdate)
         {
-            GetComponent<SpriteRenderer>().flipX = false;
+            transform.rotation = Quaternion.Euler(0, 0, 0);
+            //GetComponent<SpriteRenderer>().flipX = false;
             MoveMe(new Vector3(1 * movementSpeedMultiplier, 0, 0));
         }
 

--- a/Senior Project Infinity Run/Assets/New Assets/Player Character/Medeival Warrior/Medieval_Warrior_Movement.cs
+++ b/Senior Project Infinity Run/Assets/New Assets/Player Character/Medeival Warrior/Medieval_Warrior_Movement.cs
@@ -79,7 +79,7 @@ public class Medieval_Warrior_Movement : MonoBehaviour
 
     void GetUserInput()
     {
-        controls.shouldMoveRightNextFixedUpdate = true;
+        //controls.shouldMoveRightNextFixedUpdate = true;
         //for these getkeydown checks, need to set flag to true here and set it to false in applyuserinput. any resets here will cause missed inputs
         if (Input.GetKeyDown(UpKey))//testing change to keydown
         {
@@ -90,19 +90,19 @@ public class Medieval_Warrior_Movement : MonoBehaviour
         controls.shouldMoveLeftNextFixedUpdate = false;
         if (Input.GetKey(LeftKey))
         {
-            //controls.shouldMoveLeftNextFixedUpdate = true;
+            controls.shouldMoveLeftNextFixedUpdate = true;
         }
 
         controls.shouldMoveDownNextFixedUpdate = false;
         if (Input.GetKey(DownKey))
         {
-            //controls.shouldMoveDownNextFixedUpdate = true;
+            controls.shouldMoveDownNextFixedUpdate = true;
         }
 
-        //controls.shouldMoveRightNextFixedUpdate = false;
+        controls.shouldMoveRightNextFixedUpdate = false;
         if (Input.GetKey(RightKey))
         {
-            //controls.shouldMoveRightNextFixedUpdate = true;
+            controls.shouldMoveRightNextFixedUpdate = true;
         }      
     }
 
@@ -120,7 +120,8 @@ public class Medieval_Warrior_Movement : MonoBehaviour
         }
         if (controls.shouldMoveLeftNextFixedUpdate)
         {
-            GetComponent<SpriteRenderer>().flipX = true;
+            transform.rotation = Quaternion.Euler(0, 180f, 0);
+            //GetComponent<SpriteRenderer>().flipX = true;
             MoveMe(new Vector3(-1 * movementSpeedMultiplier, 0, 0));          
         }
         if (controls.shouldMoveDownNextFixedUpdate)
@@ -129,7 +130,8 @@ public class Medieval_Warrior_Movement : MonoBehaviour
         }
         if (controls.shouldMoveRightNextFixedUpdate)
         {
-            GetComponent<SpriteRenderer>().flipX = false;
+            transform.rotation = Quaternion.Euler(0, 0, 0);
+            //GetComponent<SpriteRenderer>().flipX = false;
             MoveMe(new Vector3(1 * movementSpeedMultiplier, 0, 0));
         }
 


### PR DESCRIPTION
1) for both the skeleton and the Medieval Warrior, it was necessary rotate the quaternion by 180 along the y axis to flip the gameobject including its children. This allowed the hitboxes for their attacks to flip as well. Previously, we only flipped the sprite, leaving the hitboxes on their starting side without flipping as they should.